### PR TITLE
[unauthorised-journey-support-signup] Only authenticate, not authorise

### DIFF
--- a/app/controllers/actions/AuthService.scala
+++ b/app/controllers/actions/AuthService.scala
@@ -33,17 +33,12 @@ import scala.concurrent.Future
 class AuthService @Inject()(val authConnector: AuthConnector, implicit val appConfig: AppConfig)
   extends FrontendController with AuthorisedFunctions {
 
-  private def delegatedAuthRule(regime: RegimeModel): Enrolment =
-    Enrolment(regime.`type`.enrolmentId)
-      .withIdentifier(regime.identifier.key.value, regime.identifier.value)
-      .withDelegatedAuthRule(regime.`type`.delegatedAuthRule)
-
   private val arn: Enrolments => Option[String] = _.getEnrolment(Constants.AgentServicesEnrolment) flatMap {
     _.getIdentifier(Constants.AgentServicesReference).map(_.value)
   }
 
   def authorise(regime: RegimeModel)(f: User[_] => Future[Result])(implicit request : Request[_], messages: Messages): Future[Result] =
-    authorised(delegatedAuthRule(regime)).retrieve(Retrievals.allEnrolments) {
+    authorised().retrieve(Retrievals.allEnrolments) {
       enrolments =>
         f(User(regime.identifier.value, arn(enrolments))(request))
     } recover {

--- a/test/connectors/mocks/MockAuthConnector.scala
+++ b/test/connectors/mocks/MockAuthConnector.scala
@@ -33,10 +33,6 @@ trait MockAuthConnector extends TestUtils with MockitoSugar {
 
   lazy val mockAuthConnector: AuthConnector = mock[AuthConnector]
 
-  val vatAuthPredicate: Predicate = Enrolment(Constants.MtdContactPreferencesEnrolmentKey)
-    .withIdentifier(Constants.MtdContactPreferencesReferenceKey, testVatNumber)
-    .withDelegatedAuthRule(Constants.MtdContactPreferencesDelegatedAuth)
-
   val allEnrolments: Retrieval[Enrolments] = Retrievals.allEnrolments
 
   def mockAuthorise[T](predicate: Predicate = EmptyPredicate,
@@ -59,9 +55,9 @@ trait MockAuthConnector extends TestUtils with MockitoSugar {
       Future.successful(Enrolments(Set(testAgentServicesEnrolment)))
     )
 
-  def mockAuthRetrieveMtdVatEnrolled(predicate: Predicate = EmptyPredicate): Unit =
+  def mockAuthenticated(predicate: Predicate = EmptyPredicate): Unit =
     mockAuthorise(predicate = predicate, retrievals = retrievals)(
-      Future.successful(Enrolments(Set(testMtdVatEnrolment)))
+      Future.successful(Enrolments(Set()))
     )
 
   override protected def beforeEach(): Unit = {

--- a/test/controllers/AuthServiceSpec.scala
+++ b/test/controllers/AuthServiceSpec.scala
@@ -22,6 +22,7 @@ import controllers.actions.AuthService
 import play.api.http.Status._
 import play.api.mvc.Result
 import play.api.mvc.Results._
+import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 import uk.gov.hmrc.auth.core.{InsufficientEnrolments, MissingBearerToken}
 
 import scala.concurrent.Future
@@ -43,7 +44,7 @@ class AuthServiceSpec extends MockAuthConnector {
       "an authorised result is returned from the Auth Connector" should {
 
         "Successfully authenticate and process the request" in {
-          mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+          mockAuthenticated(EmptyPredicate)
           status(result) shouldBe OK
         }
       }
@@ -54,7 +55,7 @@ class AuthServiceSpec extends MockAuthConnector {
       "they are Signed Up to MTD ContactPreferences" should {
 
         "Successfully authenticate and process the request" in {
-          mockAuthRetrieveAgentServicesEnrolled(vatAuthPredicate)
+          mockAuthRetrieveAgentServicesEnrolled(EmptyPredicate)
           status(result) shouldBe OK
         }
       }
@@ -65,12 +66,12 @@ class AuthServiceSpec extends MockAuthConnector {
       "a NoActiveSession exception is returned from the Auth Connector" should {
 
         "Return a SEE_OTHER response" in {
-          mockAuthorise(vatAuthPredicate, retrievals)(Future.failed(MissingBearerToken()))
+          mockAuthorise(EmptyPredicate, retrievals)(Future.failed(MissingBearerToken()))
           status(result) shouldBe SEE_OTHER
         }
 
         "Redirect to GG Sign In" in {
-          mockAuthorise(vatAuthPredicate, retrievals)(Future.failed(MissingBearerToken()))
+          mockAuthorise(EmptyPredicate, retrievals)(Future.failed(MissingBearerToken()))
           redirectLocation(result) shouldBe Some(appConfig.signInUrl)
         }
       }
@@ -78,7 +79,7 @@ class AuthServiceSpec extends MockAuthConnector {
       "an InsufficientAuthority exception is returned from the Auth Connector" should {
 
         "Return a forbidden response" in {
-          mockAuthorise(vatAuthPredicate, retrievals)(Future.failed(InsufficientEnrolments()))
+          mockAuthorise(EmptyPredicate, retrievals)(Future.failed(InsufficientEnrolments()))
           status(result) shouldBe FORBIDDEN
         }
       }

--- a/test/controllers/ContactPreferencesControllerSpec.scala
+++ b/test/controllers/ContactPreferencesControllerSpec.scala
@@ -29,6 +29,7 @@ import play.api.mvc.Result
 import play.api.test.FakeRequest
 import services.mocks.{MockJourneyService, MockPreferenceService}
 import uk.gov.hmrc.auth.core.InsufficientEnrolments
+import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 import utils.TestUtils
 
 import scala.concurrent.Future
@@ -50,7 +51,7 @@ class ContactPreferencesControllerSpec extends TestUtils with MockPreferenceServ
 
         "return an OK (200)" in {
           mockJourney(journeyId)(Right(journeyModelMax))
-          mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+          mockAuthenticated(EmptyPredicate)
 
           status(result) shouldBe Status.OK
         }
@@ -60,7 +61,7 @@ class ContactPreferencesControllerSpec extends TestUtils with MockPreferenceServ
 
         "return an FORBIDDEN (403)" in {
           mockJourney(journeyId)(Right(journeyModelMax))
-          mockAuthorise(vatAuthPredicate, retrievals)(Future.failed(InsufficientEnrolments()))
+          mockAuthorise(EmptyPredicate, retrievals)(Future.failed(InsufficientEnrolments()))
 
           status(result) shouldBe Status.FORBIDDEN
         }
@@ -97,7 +98,7 @@ class ContactPreferencesControllerSpec extends TestUtils with MockPreferenceServ
             "return an SEE_OTHER (303) status" in {
 
               mockJourney(journeyId)(Right(journeyModelMax))
-              mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+              mockAuthenticated(EmptyPredicate)
               mockStoreJourneyPreference(journeyId, Digital)(Right(Success))
 
               verifyExplicitAudit(
@@ -127,7 +128,7 @@ class ContactPreferencesControllerSpec extends TestUtils with MockPreferenceServ
             "return the error status" in {
 
               mockJourney(journeyId)(Right(journeyModelMax))
-              mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+              mockAuthenticated(EmptyPredicate)
               mockStoreJourneyPreference(journeyId, Digital)(Left(InvalidPreferencePayload))
 
               verifyExplicitAudit(
@@ -156,7 +157,7 @@ class ContactPreferencesControllerSpec extends TestUtils with MockPreferenceServ
             "return an SEE_OTHER (303) status" in {
 
               mockJourney(journeyId)(Right(journeyModelMax))
-              mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+              mockAuthenticated(EmptyPredicate)
               mockStoreJourneyPreference(journeyId, Paper)(Right(Success))
 
               verifyExplicitAudit(
@@ -186,7 +187,7 @@ class ContactPreferencesControllerSpec extends TestUtils with MockPreferenceServ
             "return the error status" in {
 
               mockJourney(journeyId)(Right(journeyModelMax))
-              mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+              mockAuthenticated(EmptyPredicate)
               mockStoreJourneyPreference(journeyId, Paper)(Left(InvalidPreferencePayload))
 
               verifyExplicitAudit(
@@ -208,7 +209,7 @@ class ContactPreferencesControllerSpec extends TestUtils with MockPreferenceServ
 
           "return a BAD_REQUEST (400)" in {
             mockJourney(journeyId)(Right(journeyModelMax))
-            mockAuthRetrieveMtdVatEnrolled(vatAuthPredicate)
+            mockAuthenticated(EmptyPredicate)
 
             val result = TestContactPreferencesController.submit(journeyId)(FakeRequest("POST", "/"))
 
@@ -221,7 +222,7 @@ class ContactPreferencesControllerSpec extends TestUtils with MockPreferenceServ
 
         "return an FORBIDDEN (403)" in {
           mockJourney(journeyId)(Right(journeyModelMax))
-          mockAuthorise(vatAuthPredicate, retrievals)(Future.failed(InsufficientEnrolments()))
+          mockAuthorise(EmptyPredicate, retrievals)(Future.failed(InsufficientEnrolments()))
 
           val result = TestContactPreferencesController.submit(journeyId)(FakeRequest("POST", "/").withFormUrlEncodedBody(
             ContactPreferencesForm.yesNo -> YesNoMapping.option_yes


### PR DESCRIPTION
- required for sign-up as the user won't have an MTD VAT enrolment yet. We still authenticate so that we know if it's an agent.